### PR TITLE
Add .gitattributes to specify Jupyter Notebook files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=Python


### PR DESCRIPTION
Adiciona configuração do linguist, considerando o arquivo .ipynb como Python